### PR TITLE
D77 Reader Fix, VFO_GAIN_L_DEFAULT to 0.3.

### DIFF
--- a/disk_image/d77img.cpp
+++ b/disk_image/d77img.cpp
@@ -65,8 +65,8 @@ void d77img::read(const std::string& file_name) {
     for (size_t track = 0; track < 164; track++) {
         size_t track_offset = image_data.get_dword_le(0x20 + track * 4);
         if (track_offset != 0) {
-            size_t num_sect = 0;
-            do {
+            size_t num_sect = image_data.get_word_le(track_offset + 4);
+            while (m_disk_data[track].size() < num_sect) {
                 sector_data sect;
                 sect.m_C = image_data.get_byte_le(track_offset + 0);
                 sect.m_H = image_data.get_byte_le(track_offset + 1);
@@ -83,8 +83,7 @@ void d77img::read(const std::string& file_name) {
                 last_track = track;
 
                 track_offset += 0x10 + sect.m_sector_data_length;
-
-            } while (m_disk_data[track].size() < num_sect);
+            }
         }
     }
     ifs.close();

--- a/disk_image/image_d77.cpp
+++ b/disk_image/image_d77.cpp
@@ -111,8 +111,9 @@ void disk_image_d77::read(const std::string file_name) {
                     break;
                 }
                 for(size_t i=0; i<sect.m_sector_data_length; i++) {
-                    codec.mfm_write_byte(sect_body[i], false, true, true);
-                    crcgen.data(sect_body[i]);
+                    uint8_t data=(i<sect.m_sector_data.size() ? sect_body[i] : 0);
+                    codec.mfm_write_byte(data, false, true, true);
+                    crcgen.data(data);
                 }
                 crcgen.data(0); crcgen.data(0);
                 crcval = crcgen.get();

--- a/include/fdc_vfo_def.h
+++ b/include/fdc_vfo_def.h
@@ -18,5 +18,5 @@
 
 #define VFO_TYPE_DESC_STR  "0:vfo_simple, 1:vfo_fixed, 2:vfo_pid, 3:vfo_pid2, 4:vfo_simple2, 5:vfo_pid3, 9:vfo_experimental"
 
-#define VFO_GAIN_L_DEFAULT  (0.4f)
+#define VFO_GAIN_L_DEFAULT  (0.3f) // 0.2f was too small.  0.4f was just a little too large.
 #define VFO_GAIN_H_DEFAULT  (1.f)


### PR DESCRIPTION
Fixed d77 reader crash on two cases (1) when there is a track with non-null pointer, but zero number of sectors, (2) when actual sector length is greater than (128<<N).  Also VFO gain-low default to 0.3.