### PR TITLE
RDD(Real Disk Dump)-format file export.

### DIFF
--- a/disk_analyzer/analyzer.cpp
+++ b/disk_analyzer/analyzer.cpp
@@ -154,7 +154,7 @@ void cmd_read_track_pulse(size_t track_n,size_t byte_offset,size_t length) {
     fdc->set_pos(0);
 
     fdc->clear_wraparound();
-    for(size_t i=0; i<byte_offset+length && fdc->is_wraparound() == false; ++i) {
+    for(size_t i=0; i<byte_offset+length; ++i) {
         auto pos = fdc->get_real_pos();
         if(pos>fdc->get_track_length()) pos = 0;         // exceptional case handling
 
@@ -180,9 +180,24 @@ void cmd_read_track_pulse(size_t track_n,size_t byte_offset,size_t length) {
 			std::cout << std::hex << std::setw(2) << std::setfill('0') << int(read_data);
 			std::cout << std::dec << std::setw(10) << std::setfill(' ') << pos;
 			std::cout << "   ";
-			for(int j=pos; j<pos_end; ++j)
+			if(pos<=pos_end)
 			{
-				std::cout << (int(track_stream.get(j)) ? "#":".");
+				for(int j=pos; j<pos_end; ++j)
+				{
+					std::cout << (int(track_stream.get(j)) ? "#":".");
+				}
+			}
+			else // Wrapped around
+			{
+				for(int j=pos; j<track_stream.get_bit_length(); ++j)
+				{
+					std::cout << (int(track_stream.get(j)) ? "#":".");
+				}
+				std::cout << "W";
+				for(int j=0; j<pos_end; ++j)
+				{
+					std::cout << (int(track_stream.get(j)) ? "#":".");
+				}
 			}
 
 			std::cout << std::endl;

--- a/disk_image/image_rdd.cpp
+++ b/disk_image/image_rdd.cpp
@@ -456,8 +456,9 @@ bool disk_image_rdd::CheckCorocoroTypeASignature(bool crc_sts,const std::vector 
 				return false;
 			}
 		}
+		return true;
 	}
-	return true;
+	return false;
 }
 bool disk_image_rdd::CheckCorocoroTypeBSignature(bool crc_sts,const std::vector <uint8_t> &data) const
 {
@@ -483,6 +484,7 @@ bool disk_image_rdd::CheckCorocoroTypeBSignature(bool crc_sts,const std::vector 
 				return false;
 			}
 		}
+		return true;
 	}
-	return true;
+	return false;
 }

--- a/disk_image/image_rdd.cpp
+++ b/disk_image/image_rdd.cpp
@@ -586,10 +586,15 @@ std::vector <bool> disk_image_rdd::MarkUnstablePulses(fdc_bitstream &fdc,const s
 		confirmed[i]=false;
 	}
 
-	// First read sectors, and all bits should be marked stable if there is no CRC error.
+	// If there is no CRC error in the ID mark, then the pulses must be marked stable.
+	// If there is no CRC error in the sector, and all pulses within the sector should be marked stable if there is no CRC error.
 	fdc.set_pos(0);
 	for(auto id : id_list)
 	{
+		if(true==id.crc_sts)
+		{
+			Fill(id.pos,id.end_pos,false);
+		}
         fdc.set_pos(Rewind(id.pos));
         auto read_sect = fdc.read_sector(id.C, id.R);
         if(true==read_sect.crc_sts) // No CRC Error.  Unlikely to include an unstable bit.

--- a/disk_image/image_rdd.cpp
+++ b/disk_image/image_rdd.cpp
@@ -191,6 +191,13 @@ bool disk_image_rdd::write(std::ostream &ofp) const {
                 else
                 {
                     sectorHeader[5]|=MB8877_STATUS_RECORD_NOT_FOUND;
+                    // Observed in ASTEKA.  Data mark of C0 H0 R20 does not exist, therefore
+                    // record not found error.  At the same time, because IDMark was making
+                    // a CRC error, so crc error flag was also set.
+                    if(true==id.crc_sts)
+                    {
+                        sectorHeader[5]|=MB8877_STATUS_CRC_ERROR;
+                    }
                 }
 
                 auto start_pos=read_sect.data_pos;

--- a/disk_image/image_rdd.cpp
+++ b/disk_image/image_rdd.cpp
@@ -314,7 +314,7 @@ bool disk_image_rdd::write(std::ostream &ofp) const {
     std::cout.flags(flags_saved);
 }
 
-bool disk_image_rdd::IsFM7CorocoroTypeA(fdc_bitstream &fdc,uint64_t pos,unsigned char C,unsigned char H,bool crc_sts,const std::vector <uint8_t> &data) const
+bool disk_image_rdd::IsFM7CorocoroTypeA(fdc_bitstream &fdc,uint64_t pos,unsigned char C,unsigned char R,bool crc_sts,const std::vector <uint8_t> &data) const
 {
 	if(true==CheckCorocoroTypeASignature(crc_sts,data))
 	{
@@ -331,7 +331,7 @@ bool disk_image_rdd::IsFM7CorocoroTypeA(fdc_bitstream &fdc,uint64_t pos,unsigned
 			for(int i=0; i<nRepeat; ++i)
 			{
 				fdc.set_pos(pos);
-				auto sect=fdc.read_sector(C,H);
+				auto sect=fdc.read_sector(C,R);
 				if(1024!=sect.data.size())
 				{
 					goto UPDATE_FLUCTUATION;
@@ -381,7 +381,7 @@ bool disk_image_rdd::IsFM7CorocoroTypeA(fdc_bitstream &fdc,uint64_t pos,unsigned
 	}
 	return false;
 }
-bool disk_image_rdd::IsFM7CorocoroTypeB(fdc_bitstream &fdc,uint64_t pos,unsigned char C,unsigned char H,bool crc_sts,const std::vector <uint8_t> &data) const
+bool disk_image_rdd::IsFM7CorocoroTypeB(fdc_bitstream &fdc,uint64_t pos,unsigned char C,unsigned char R,bool crc_sts,const std::vector <uint8_t> &data) const
 {
 	if(true==CheckCorocoroTypeBSignature(crc_sts,data))
 	{
@@ -398,7 +398,7 @@ bool disk_image_rdd::IsFM7CorocoroTypeB(fdc_bitstream &fdc,uint64_t pos,unsigned
 			for(int i=0; i<nRepeat; ++i)
 			{
 				fdc.set_pos(pos);
-				auto sect=fdc.read_sector(C,H);
+				auto sect=fdc.read_sector(C,R);
 				if(128!=sect.data.size())
 				{
 					goto UPDATE_FLUCTUATION;

--- a/disk_image/image_rdd.cpp
+++ b/disk_image/image_rdd.cpp
@@ -1,0 +1,245 @@
+#include "image_rdd.h"
+#include "byte_array.h"
+
+#include "fdc_bitstream.h"
+
+#include <fstream>
+#include <iostream>
+#include <iomanip>
+
+#define MB8877_STATUS_CRC_ERROR        0x08
+#define MB8877_STATUS_RECORD_NOT_FOUND 0x10
+#define MB8877_STATUS_DELETED_DATA     0x20
+
+void disk_image_rdd::read(const std::string file_name) {
+    std::cout << "Reading from RDD is not supported yet." << std::endl;
+}
+
+void disk_image_rdd::read(std::istream &ifp) {
+    std::cout << "Reading from RDD is not supported yet." << std::endl;
+}
+
+
+void disk_image_rdd::write(const std::string file_name) const {
+    std::ofstream ofp(file_name,std::ios::binary);
+    write(ofp);
+}
+
+bool disk_image_rdd::write(std::ostream &ofp) const {
+    const size_t sector_length_table[] = { 128, 256, 512, 1024 };
+    std::ios::fmtflags flags_saved = std::cout.flags();
+    fdc_bitstream fdc;
+
+
+    static char padding[1024];
+    for(auto &p : padding) {
+        p=0;
+    }
+
+
+    char fileID[16]={
+        'R','E','A','L','D','I','S','K','D','U','M','P',0,0,0,0
+    };
+    ofp.write(fileID,16);
+
+    unsigned char beginDisk[16]={0,0,0,0,0,0,0,0};
+    beginDisk[1]=0; // Version
+    if(m_base_prop.m_data_bit_rate == 1e6) {   // 1Mbps == 2HD_MFM , 500Kbps == 2D/2DD_MFM
+        beginDisk[2] = 0x20;        // 2HD
+    } else if (m_base_prop.m_number_of_tracks > 84) {
+        beginDisk[2] = 0x10;        // 2DD
+    }
+    else {
+        beginDisk[2]=0; // Assume 2D.
+    }
+    beginDisk[3]=0; // Write Protected -> 1
+    beginDisk[4]=0xFF; // Converted.  Not directly from real device.
+    ofp.write((char *)beginDisk,16);
+
+    char diskName[32];
+    memset(diskName,0,32);
+    ofp.write(diskName,32);
+
+
+    size_t total_sector_good = 0;
+    size_t total_sector_bad = 0;
+
+    fdc.set_fdc_params(m_base_prop.m_sampling_rate,m_base_prop.m_data_bit_rate);
+
+    for (size_t track_n = 0; track_n < m_base_prop.m_number_of_tracks; track_n++) {
+        if(m_verbose) {
+            std::cout << std::setw(4) << std::dec << track_n << ":";
+        }
+
+        unsigned char beginTrack[16]={1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+        beginTrack[1]=track_n/2; // Cylinder
+        beginTrack[2]=track_n%2; // Head
+        ofp.write((char *)beginTrack,16);
+
+        size_t sector_good=0,sector_bad=0;
+
+        for(int retry=0; retry<2; ++retry) // Try MFM, and then FM
+        {
+            const bool MFM=(0==retry ? true : false);
+
+            bit_array mfm_trk = m_track_data[track_n];
+            fdc.set_track_data(mfm_trk);
+            fdc.set_pos(0);
+            fdc.set_vfo_type(m_vfo_type);
+            fdc.set_vfo_gain_val(m_gain_l, m_gain_h);
+            std::vector<fdc_bitstream::id_field> id_list = fdc.read_all_idam();
+
+            if(0==retry && 0==id_list.size())
+            {
+                // Try again.  Unformat or can be FM format.
+                continue;
+            }
+
+
+            for(auto id : id_list) {
+                unsigned char idMark[16]={2,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+                idMark[1]=id.C;
+                idMark[2]=id.H;
+                idMark[3]=id.R;
+                idMark[4]=id.N;
+                idMark[5]=(id.crc_val>>8);
+                idMark[6]=(id.crc_val&0xFF);
+                if(true==id.crc_sts) {
+                    idMark[7]|=MB8877_STATUS_CRC_ERROR;
+                }
+
+                fdc.set_pos(id.pos);
+                auto read_sect = fdc.read_sector(id.C, id.R);
+
+                if(true==read_sect.record_not_found) {
+                    idMark[7]|=MB8877_STATUS_RECORD_NOT_FOUND;
+                }
+
+                ofp.write((char *)idMark,16);
+            }
+
+            for(auto id : id_list) {
+                unsigned char sectorHeader[16]={3,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+                sectorHeader[1]=id.C;
+                sectorHeader[2]=id.H;
+                sectorHeader[3]=id.R;
+                sectorHeader[4]=id.N;
+
+                if(true!=MFM)
+                {
+                    sectorHeader[6]|=1;
+                }
+                // if(true==needResample)
+                //{
+                //    sectorHeader[6]|=2;
+                //}
+                // if(true==leafInTheForest)
+                //{
+                //    sectorHeader[6]|=4;
+                //}
+
+
+                fdc.set_pos(id.pos);
+                auto read_sect = fdc.read_sector(id.C, id.R);
+
+                if(read_sect.record_not_found == false) {
+                    if(true==read_sect.dam_type) {
+                        sectorHeader[5]|=MB8877_STATUS_DELETED_DATA;
+                    }
+                    if(true==read_sect.crc_sts)
+                    {
+                        sectorHeader[5]|=MB8877_STATUS_CRC_ERROR;
+                    }
+                }
+                else
+                {
+                    sectorHeader[5]|=MB8877_STATUS_RECORD_NOT_FOUND;
+                }
+
+                auto start_pos=read_sect.data_pos;
+                auto end_pos=read_sect.data_end_pos;;
+                if (end_pos < start_pos) {
+                    end_pos += mfm_trk.get_bit_length();       // wrap around correction
+                }
+
+                uint64_t elapsed=end_pos-start_pos;
+                uint64_t microsec=elapsed*1000000LL/(uint64_t)m_base_prop.m_sampling_rate;
+                sectorHeader[0x0B]= microsec     &0xFF;
+                sectorHeader[0x0C]=(microsec>> 8)&0xFF;
+                sectorHeader[0x0D]=(microsec>>16)&0xFF;
+
+                if(m_verbose) {
+                    std::cout << int(id.C) << " " << int(id.H) << " " << int(id.R) << " POS0:" << id.pos << " POS1:" << fdc.get_real_pos() << " " << microsec << "usec" << std::endl;
+                }
+
+                unsigned int len=(128<<(id.N&3));
+                sectorHeader[0x0E]= len    &0xFF;
+                sectorHeader[0x0F]=(len>>8)&0xFF;
+
+                int resampleCount=1;
+                for(int i=0; i<resampleCount; ++i)
+                {
+                    if(0<i)
+                    {
+                        // Randomize identified unstable bytes.
+                    }
+                    ofp.write((char *)sectorHeader,16);
+                    while(read_sect.data.size()<len)
+                    {
+                        read_sect.data.push_back(0);
+                    }
+                    read_sect.data.resize(len);
+
+                    ofp.write((char *)read_sect.data.data(),read_sect.data.size());
+                }
+
+                if (!read_sect.record_not_found && !read_sect.crc_sts && !id.crc_sts) {  // no error (RNF or DT_CRC error or ID_CRC error)
+                    sector_good++;
+                    total_sector_good++;
+                } else {
+                    sector_bad++;
+                    total_sector_bad++;
+                }
+            }
+
+
+            // Read Track
+            fdc.set_pos(0);
+            auto track_read = fdc.read_track();
+            unsigned char trackReadHeader[16]={4,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0};
+            trackReadHeader[1]=track_n/2; // Cylinder
+            trackReadHeader[2]=track_n%2; // Head
+            // trackReadHeader[3] MB8877 status, but I'm vague about what it should be.
+            trackReadHeader[0x0E]= track_read.size()    &0xFF;
+            trackReadHeader[0x0F]=(track_read.size()>>8)&0xFF;
+
+            while(0!=track_read.size()%16)
+            {
+                track_read.push_back(0);
+            }
+            ofp.write((char *)trackReadHeader,16);
+            ofp.write((char *)track_read.data(),track_read.size());
+
+
+            if(m_verbose) {
+                std::cout << std::setw(4) << std::dec << (sector_good+sector_bad) << "/" << std::setw(4) << sector_bad << "  ";
+                if(track_n % 5 == 4) {
+                    std::cout << std::endl;
+                }
+            }
+
+            break; // If it reaches here, don't continue.
+        }
+
+        char endTrack[16]={5,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0};
+        ofp.write(endTrack,16);
+    }
+    char endFile[16]={6,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0};
+    ofp.write(endFile,16);
+
+    if(m_verbose) {
+        std::cout << std::endl;
+        std::cout << "**TOTAL RESULT(GOOD/BAD):" << total_sector_good << " " << total_sector_bad << std::endl;
+    }
+    std::cout.flags(flags_saved);
+}

--- a/fdc_bitstream/fdc_bitstream.cpp
+++ b/fdc_bitstream/fdc_bitstream.cpp
@@ -246,6 +246,7 @@ std::vector<fdc_bitstream::id_field> fdc_bitstream::read_all_idam(void) {
             item.crc_val = (sect_id[4] << 8) + sect_id[5];
             item.crc_sts = crc_error;
             item.pos = pos;
+            item.end_pos = m_codec.get_real_pos();
             result.push_back(item);
         }
     }

--- a/fdc_bitstream/mfm_codec.cpp
+++ b/fdc_bitstream/mfm_codec.cpp
@@ -483,7 +483,8 @@ size_t mfm_codec::get_real_pos(void)
 	size_t int_dist = static_cast<size_t>(m_distance_to_next_pulse);
 	if(m_track.get_stream_pos() < int_dist)
 	{
-		return -1;
+		int_dist-=m_track.get_stream_pos();
+		return m_track.size()-int_dist;
 	}
 
     return m_track.get_stream_pos()-int_dist;

--- a/image_converter/image_converter.cpp
+++ b/image_converter/image_converter.cpp
@@ -24,7 +24,7 @@
 void usage(std::string cmd_name) {
     std::cout << cmd_name << "-i input_file -o output_file [-n]" << std::endl;
     std::cout << "Input file     : mfm, raw, d77, hfe, fdx" << std::endl;
-    std::cout << "Output file    : mfm, raw, d77, hfe, fdx" << std::endl;
+    std::cout << "Output file    : mfm, raw, d77, hfe, fdx, rdd" << std::endl;
     std::cout << "-n             : Normalize pulse pitch. Get statistic data of pulse-to-pulse distance \n"
                  "                 distribution in a track and align bit position with standard bit cell pitch.\n"
                  "                 This will make the disk image data easy to read." << std::endl;
@@ -47,7 +47,7 @@ std::string get_file_extension(std::string file_name) {
 }
 
 bool check_extension(std::string extension) {
-    std::vector<std::string> allowed = { "hfe", "mfm", "raw", "d77", "fdx" };
+    std::vector<std::string> allowed = { "hfe", "mfm", "raw", "d77", "rdd", "fdx" };
     bool res = false;
     for(auto it = allowed.begin(); it != allowed.end(); ++it) {
         if(*it == extension) res = true;
@@ -61,6 +61,7 @@ disk_image* create_object_by_ext(std::string ext) {
     if(ext == "raw") obj = new disk_image_raw();
     if(ext == "mfm") obj = new disk_image_mfm();
     if(ext == "d77") obj = new disk_image_d77();
+    if(ext == "rdd") obj = new disk_image_rdd();
     if(ext == "fdx") obj = new disk_image_fdx();
     return obj;
 }

--- a/include/disk_images.h
+++ b/include/disk_images.h
@@ -5,4 +5,5 @@
 #include "image_raw.h"
 #include "image_mfm.h"
 #include "image_d77.h"
+#include "image_rdd.h"
 #include "image_fdx.h"

--- a/include/fdc_bitstream.h
+++ b/include/fdc_bitstream.h
@@ -44,6 +44,7 @@ public:
         uint16_t    crc_val;
         bool        crc_sts;
         size_t      pos;
+        size_t      end_pos;
     };
 
     /** 

--- a/include/image_rdd.h
+++ b/include/image_rdd.h
@@ -19,4 +19,10 @@ public:
     bool write(std::ostream &ofp) const ;
     void set_vfo_type(const size_t vfo_type) override { m_vfo_type = vfo_type; };
     void set_gain(double gain_l, double gain_h) override { m_gain_l = gain_l; m_gain_h = gain_h; };
+
+	bool IsFM7CorocoroTypeA(class fdc_bitstream &fdc,uint64_t pos,unsigned char C,unsigned char H,bool crc_sts,const std::vector <uint8_t> &data) const;
+	bool IsFM7CorocoroTypeB(class fdc_bitstream &fdc,uint64_t pos,unsigned char C,unsigned char H,bool crc_sts,const std::vector <uint8_t> &data) const;
+
+	bool CheckCorocoroTypeASignature(bool crc_sts,const std::vector <uint8_t> &data) const;
+	bool CheckCorocoroTypeBSignature(bool crc_sts,const std::vector <uint8_t> &data) const;
 };

--- a/include/image_rdd.h
+++ b/include/image_rdd.h
@@ -20,8 +20,8 @@ public:
     void set_vfo_type(const size_t vfo_type) override { m_vfo_type = vfo_type; };
     void set_gain(double gain_l, double gain_h) override { m_gain_l = gain_l; m_gain_h = gain_h; };
 
-	bool IsFM7CorocoroTypeA(class fdc_bitstream &fdc,uint64_t pos,unsigned char C,unsigned char H,bool crc_sts,const std::vector <uint8_t> &data) const;
-	bool IsFM7CorocoroTypeB(class fdc_bitstream &fdc,uint64_t pos,unsigned char C,unsigned char H,bool crc_sts,const std::vector <uint8_t> &data) const;
+	bool IsFM7CorocoroTypeA(class fdc_bitstream &fdc,uint64_t pos,unsigned char C,unsigned char H,unsigned char R,bool crc_sts,const std::vector <uint8_t> &data) const;
+	bool IsFM7CorocoroTypeB(class fdc_bitstream &fdc,uint64_t pos,unsigned char C,unsigned char H,unsigned char R,bool crc_sts,const std::vector <uint8_t> &data) const;
 
 	bool CheckCorocoroTypeASignature(bool crc_sts,const std::vector <uint8_t> &data) const;
 	bool CheckCorocoroTypeBSignature(bool crc_sts,const std::vector <uint8_t> &data) const;

--- a/include/image_rdd.h
+++ b/include/image_rdd.h
@@ -5,6 +5,7 @@
 #include "bit_array.h"
 #include "image_base.h"
 #include "fdc_vfo_def.h"
+#include "fdc_bitstream.h"
 
 class disk_image_rdd : public disk_image {
 private:
@@ -25,4 +26,6 @@ public:
 
 	bool CheckCorocoroTypeASignature(bool crc_sts,const std::vector <uint8_t> &data) const;
 	bool CheckCorocoroTypeBSignature(bool crc_sts,const std::vector <uint8_t> &data) const;
+
+	bool CheckLeafInTheForestSignature(uint8_t C,uint8_t H,const std::vector <fdc_bitstream::id_field> &id_list) const;
 };

--- a/include/image_rdd.h
+++ b/include/image_rdd.h
@@ -11,7 +11,7 @@ private:
     size_t m_vfo_type;
     double m_gain_l, m_gain_h;
 public:
-    disk_image_rdd(void) : disk_image(), m_vfo_type(VFO_TYPE_DEFAULT), m_gain_l(1.f), m_gain_h(2.f) {};
+    disk_image_rdd(void) : disk_image(), m_vfo_type(VFO_TYPE_DEFAULT), m_gain_l(VFO_GAIN_L_DEFAULT), m_gain_h(VFO_GAIN_H_DEFAULT) {};
 
     void read(const std::string file_name) override;
     void read(std::istream &ifp);

--- a/include/image_rdd.h
+++ b/include/image_rdd.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string.h>
+
+#include "bit_array.h"
+#include "image_base.h"
+#include "fdc_vfo_def.h"
+
+class disk_image_rdd : public disk_image {
+private:
+    size_t m_vfo_type;
+    double m_gain_l, m_gain_h;
+public:
+    disk_image_rdd(void) : disk_image(), m_vfo_type(VFO_TYPE_DEFAULT), m_gain_l(1.f), m_gain_h(2.f) {};
+
+    void read(const std::string file_name) override;
+    void read(std::istream &ifp);
+    void write(const std::string file_name) const override;
+    bool write(std::ostream &ofp) const ;
+    void set_vfo_type(const size_t vfo_type) override { m_vfo_type = vfo_type; };
+    void set_gain(double gain_l, double gain_h) override { m_gain_l = gain_l; m_gain_h = gain_h; };
+};

--- a/include/image_rdd.h
+++ b/include/image_rdd.h
@@ -28,4 +28,6 @@ public:
 	bool CheckCorocoroTypeBSignature(bool crc_sts,const std::vector <uint8_t> &data) const;
 
 	bool CheckLeafInTheForestSignature(uint8_t C,uint8_t H,const std::vector <fdc_bitstream::id_field> &id_list) const;
+
+	std::vector <bool> MarkUnstablePulses(fdc_bitstream &fdc,const std::vector<fdc_bitstream::id_field> &id_list) const;
 };

--- a/pauline2raw/pauline2raw.cpp
+++ b/pauline2raw/pauline2raw.cpp
@@ -740,6 +740,45 @@ bool PaulineToRaw::ExportRaw(std::string fName,const std::vector <HxCStream::Tra
 				int searchBytes=4;
 				size_t searchWindowSize=256; // Ad-hoc
 				iEnd=hxc.ExactCut(iStart,iEnd,16*searchBytes,searchWindowSize); // 16 pulses for one byte.
+
+				// iStart=1
+				// iEnd=40762
+				// [40756]306
+				// [40757]406
+				// [40758]289
+				// [40759]212
+				// [40760]289
+				// [40761]218
+				// [40762]393 iEnd     [0]196    <- Pauline started in the middle of the first pulse?
+				// [40763]210          [1]210    iStart
+				// [40764]293          [2]292
+				// [40765]294          [3]297
+				// [40766]212          [4]210
+				// [40767]293          [5]293
+				// [40768]207          [6]208
+				// [40769]200          [7]201
+				// [40770]295          [8]293
+				// [40771]207          [9]207
+				// [40772]198          [10]198
+				// [40773]202          [11]204
+				// [40774]200          [12]199
+				// [40775]202          [13]201
+
+				// fdc_bitstream seems to assume when wrapped around, there is no pulse at the connecting point.
+				// which makes sense, because there is no guarantee that the pulse was not cut across the index hole.
+				// However, ExactCut will cut exactly at a pulse.  In the above sample, a pulse is needed between
+				// pulse[40762] and pulse[1] when wrapped around.
+				// Therefore, it requires this trick.
+				++iEnd;
+				if(hxc.pulse.size()<=iEnd)
+				{
+					hxc.pulse.push_back(0);
+				}
+				if(iEnd<hxc.pulse.size())
+				{
+					hxc.pulse[iEnd]=hxc.pulse[iStart]/2;
+					hxc.pulse[iStart]-=hxc.pulse[iEnd];
+				}
 			}
 
 			iEnd=hxc.MakeOverlap(iStart,iEnd,overlap);


### PR DESCRIPTION
津軽・陸奥で使用可能なRDD形式のディスクイメージのExport機能を追加しました。まだImportはできないのですが。
これまでのテストでは変換したディスクの大雑把に90%以上がそのまま陸奥上で少なくとも起動まできています。